### PR TITLE
(field): Add new phoneNumber field on user entity

### DIFF
--- a/migration/1581976641703-AddPhoneNumberOnUser.ts
+++ b/migration/1581976641703-AddPhoneNumberOnUser.ts
@@ -4,7 +4,7 @@ export class AddPhoneNumberOnUser1581976641703 implements MigrationInterface {
   public async up(queryRunner: QueryRunner): Promise<any> {
     await queryRunner.query(
       `ALTER TABLE site_user
-        ADD COLUMN phoneNumber varchar(13)  NOT NULL;`,
+        ADD COLUMN phoneNumber varchar(15)  NOT NULL;`,
       undefined,
     );
   }

--- a/migration/1581976641703-AddPhoneNumberOnUser.ts
+++ b/migration/1581976641703-AddPhoneNumberOnUser.ts
@@ -1,0 +1,20 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddPhoneNumberOnUser1581976641703 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<any> {
+    await queryRunner.query(
+      `ALTER TABLE site_user
+        ADD COLUMN phoneNumber varchar(13)  NOT NULL;`,
+      undefined,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<any> {
+    await queryRunner.query(
+      `
+    ALTER TABLE site_user 
+    DROP COLUMN phoneNumber;`,
+      undefined,
+    );
+  }
+}

--- a/src/user/interfaces/user.dto.ts
+++ b/src/user/interfaces/user.dto.ts
@@ -7,12 +7,14 @@
 export class UserOwnInfoDto {
     readonly displayName: string;
     readonly email: string;
+    readonly phoneNumber: string;
     readonly publicId: string;    
 }
 
 export class RegisterUserDto {
     email: string;
     displayName: string;
+    phoneNumber: string;
 }
 
 export class ConfirmUserDto {

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -17,10 +17,11 @@ export class UserController {
         type: UserOwnInfoDto
       })    
     async register(@Body() data: RegisterUserDto): Promise<UserOwnInfoDto> {
-        const u = await this.userService.register(data.email, data.displayName);                
+        const u = await this.userService.register(data.email, data.displayName, data.phoneNumber);                
         return {
             email: u.pendingEmail,  // Emails get lowercased 
             displayName: u.displayName,
+            phoneNumber: u.phoneNumber,
             publicId: u.publicId
         }
     }    

--- a/src/user/user.entity.ts
+++ b/src/user/user.entity.ts
@@ -59,11 +59,11 @@ export class User {
     emailConfirmationCompletedAt: Date;
     
     // TODO: Phone number field
-    @Column({ length: 13, nullable: false })
-    @IsNotEmpty()
-    @Matches(/^[+]35[0-9]{10}$/, {
-        message: "Invalid phone number"
+    @Column({ length: 15, nullable: false })
+    @Matches(/^[+]\d*$/, {
+        message: "Invalid phone number: Missing country code"
     })
+    @IsNotEmpty()
     phoneNumber: string;
 
     // We ignore the password field in the context of this exercise,

--- a/src/user/user.entity.ts
+++ b/src/user/user.entity.ts
@@ -1,5 +1,5 @@
 import { Entity, PrimaryGeneratedColumn, Column, Generated, CreateDateColumn, UpdateDateColumn } from 'typeorm';
-import {IsEmail, IsOptional} from "class-validator";
+import {IsEmail, IsOptional, IsNotEmpty, Matches} from "class-validator";
 
 
 
@@ -59,6 +59,12 @@ export class User {
     emailConfirmationCompletedAt: Date;
     
     // TODO: Phone number field
+    @Column({ length: 13, nullable: false })
+    @IsNotEmpty()
+    @Matches(/^[+]35[0-9]{10}$/, {
+        message: "Invalid phone number"
+    })
+    phoneNumber: string;
 
     // We ignore the password field in the context of this exercise,
     // as asking a truly safe password management routines 

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -49,7 +49,7 @@ export class UserService {
         const u = new User();
         u.displayName = displayName;
         u.pendingEmail = email;
-        u.phoneNumber = phoneNumber;
+        u.phoneNumber = this.cleanPhoneNumber(phoneNumber);
         u.emailConfirmationRequestedAt = new Date();
         // https://stackoverflow.com/a/47496558/315168
         u.emailConfirmationToken = [...Array(16)].map(() => Math.random().toString(36)[2]).join(''); // TODO: Add a crypto secure user reasdable random token
@@ -149,5 +149,9 @@ export class UserService {
         await this.userRepository.save(record);
         return record;
     }    
+
+    cleanPhoneNumber(phoneNumber = '') {
+        return phoneNumber.trim().replace(/[^+0-9]/g, '');
+    }
             
 }

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -32,7 +32,7 @@ export class UserService {
         return await this.userRepository.find();
     }        
 
-    async register(email: string, displayName: string): Promise<User> {
+    async register(email: string, displayName: string, phoneNumber: string): Promise<User> {
         
         email = email.toLowerCase();
         
@@ -49,6 +49,7 @@ export class UserService {
         const u = new User();
         u.displayName = displayName;
         u.pendingEmail = email;
+        u.phoneNumber = phoneNumber;
         u.emailConfirmationRequestedAt = new Date();
         // https://stackoverflow.com/a/47496558/315168
         u.emailConfirmationToken = [...Array(16)].map(() => Math.random().toString(36)[2]).join(''); // TODO: Add a crypto secure user reasdable random token

--- a/test/user.e2e-spec.ts
+++ b/test/user.e2e-spec.ts
@@ -181,24 +181,33 @@ describe('User', () => {
       
     });    
 
+
+    it('Should accepct valid numbers with space and cleaning spaces', async () => {
+
+      const {body} = await supertest
+        .agent(app.getHttpServer())
+        .post('/users/register')
+        .send({
+          displayName: "Nooby Noob",
+          email: "nooby@example.com",
+          phoneNumber: "+55 84 98831-9033"
+        })
+        .set('Accept', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(201);
+
+        expect(body).toMatchObject({phoneNumber: "+5584988319033"});
+
+        // Check that the opbject was persistent in the database
+        const [userOne] = await repository.find();
+        expect(userOne.phoneNumber).toBe("+5584988319033");
+
+    });  
+
     describe('should return error on invalid phone numbers', () => {
 
-      it('on country code different of 35', async () => {
-        await supertest
-          .agent(app.getHttpServer())
-          .post('/users/register')
-          .send({
-            displayName: "Nooby Noob",
-            email: "nooby@example.com",
-            phoneNumber: "+378401231234"
-          })
-          .set('Accept', 'application/json')
-          .expect('Content-Type', /json/)
-          .expect(500);
-      });
-
       it('on without plus character', async () => {
-        await supertest
+        const {body} =await supertest
         .agent(app.getHttpServer())
         .post('/users/register')
         .send({
@@ -209,25 +218,13 @@ describe('User', () => {
         .set('Accept', 'application/json')
         .expect('Content-Type', /json/)
         .expect(500);
-      });
 
-      it('on incomplete phone number', async () => {
-        await supertest
-        .agent(app.getHttpServer())
-        .post('/users/register')
-        .send({
-          displayName: "Nooby Noob",
-          email: "nooby@example.com",
-          phoneNumber: "+351234"
-        })
-        .set('Accept', 'application/json')
-        .expect('Content-Type', /json/)
-        .expect(500);
+        expect(body.errorMessage).toBe('Invalid phone number: Missing country code')
       });
 
       it('on empty value', async () => {
 
-        await supertest
+        const {body} = await supertest
           .agent(app.getHttpServer())
           .post('/users/register')
           .send({
@@ -239,6 +236,7 @@ describe('User', () => {
           .expect('Content-Type', /json/)
           .expect(500);
 
+          expect(body.errorMessage).toBe('phoneNumber should not be empty')
       });    
     });
 

--- a/test/user.e2e-spec.ts
+++ b/test/user.e2e-spec.ts
@@ -61,20 +61,22 @@ describe('User', () => {
         .post('/users/register')
         .send({
           displayName: "Nooby Noob",
-          email: "nooby@example.com"
+          email: "nooby@example.com",
+          phoneNumber: "+358401231234"
         })
         .set('Accept', 'application/json')
         .expect('Content-Type', /json/)
         .expect(201);
         // https://stackoverflow.com/a/47904961/315168
-      expect(body).toMatchObject({displayName: "Nooby Noob", email: "nooby@example.com"});
+      expect(body).toMatchObject({displayName: "Nooby Noob", email: "nooby@example.com", phoneNumber: '+358401231234'});
 
       // Check that the opbject was persistent in the database
-      let [userOne] = await repository.find();
+      const [userOne] = await repository.find();
       
       expect(userOne.confirmedEmail).toBeNull(); // Separate call to confirmation needed
       expect(userOne.pendingEmail).toBe("nooby@example.com");
       expect(userOne.displayName).toBe("Nooby Noob");
+      expect(userOne.phoneNumber).toBe("+358401231234");
       expect(userOne.emailConfirmationToken).not.toBeNull();
 
     });    
@@ -86,28 +88,30 @@ describe('User', () => {
         .post('/users/register')
         .send({
           displayName: "Nooby Noob",
-          email: "nooby@example.com"
+          email: "nooby@example.com",
+          phoneNumber: "+358401231234"
         })
         .set('Accept', 'application/json')
         .expect('Content-Type', /json/)
         .expect(201);
 
       // https://stackoverflow.com/a/47904961/315168
-      expect(body).toMatchObject({displayName: "Nooby Noob", email: "nooby@example.com"});
+      expect(body).toMatchObject({displayName: "Nooby Noob", email: "nooby@example.com", phoneNumber: '+358401231234'});
 
       const { body: body2 } = await supertest
         .agent(app.getHttpServer())
         .post('/users/register')
         .send({
           displayName: "Boom Headshotter",
-          email: "boom@example.com"
+          email: "boom@example.com",
+          phoneNumber: "+358401231234"
         })
         .set('Accept', 'application/json')
         .expect('Content-Type', /json/)
         .expect(201);
 
       // https://stackoverflow.com/a/47904961/315168
-      expect(body2).toMatchObject({displayName: "Boom Headshotter", email: "boom@example.com"});
+      expect(body2).toMatchObject({displayName: "Boom Headshotter", email: "boom@example.com", phoneNumber: '+358401231234'});
     
     });        
 
@@ -118,7 +122,8 @@ describe('User', () => {
         .post('/users/register')
         .send({
           displayName: "Nooby Noob",
-          email: "nooby@example.com"
+          email: "nooby@example.com",
+          phoneNumber: "+358401231234"
         })
         .set('Accept', 'application/json')
         .expect('Content-Type', /json/)
@@ -129,14 +134,15 @@ describe('User', () => {
         .post('/users/register')
         .send({
           displayName: "Nooby Noob",
-          email: "nooby@example.com"
+          email: "nooby@example.com",
+          phoneNumber: "+358401231234"
         })
         .set('Accept', 'application/json')
         .expect('Content-Type', /json/)
         .expect(500);
 
       // Check that the opbject was persistent in the database
-      let users = await repository.find();
+      const users = await repository.find();
       expect(users.length).toBe(1);
       
     });
@@ -148,7 +154,8 @@ describe('User', () => {
         .post('/users/register')
         .send({
           displayName: "Nooby Noob",
-          email: "Nooby@Example.com"
+          email: "Nooby@Example.com",
+          phoneNumber: "+358401231234"
         })
         .set('Accept', 'application/json')
         .expect('Content-Type', /json/)
@@ -166,13 +173,74 @@ describe('User', () => {
       expect(body).toEqual({email: "nooby@example.com"});
 
       // Check that the opbject was persistent in the database
-      let [userOne] = await repository.find();
+      const [userOne] = await repository.find();
       expect(userOne.confirmedEmail).toBe("nooby@example.com"); // Separate call to confirmation needed
       expect(userOne.pendingEmail).toBe("nooby@example.com");
       expect(userOne.emailConfirmationCompletedAt).not.toBeNull();
       expect(userOne.emailConfirmationToken).toBeNull();
       
     });    
+
+    describe('should return error on invalid phone numbers', () => {
+
+      it('on country code different of 35', async () => {
+        await supertest
+          .agent(app.getHttpServer())
+          .post('/users/register')
+          .send({
+            displayName: "Nooby Noob",
+            email: "nooby@example.com",
+            phoneNumber: "+378401231234"
+          })
+          .set('Accept', 'application/json')
+          .expect('Content-Type', /json/)
+          .expect(500);
+      });
+
+      it('on without plus character', async () => {
+        await supertest
+        .agent(app.getHttpServer())
+        .post('/users/register')
+        .send({
+          displayName: "Nooby Noob",
+          email: "nooby@example.com",
+          phoneNumber: "378401231234"
+        })
+        .set('Accept', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(500);
+      });
+
+      it('on incomplete phone number', async () => {
+        await supertest
+        .agent(app.getHttpServer())
+        .post('/users/register')
+        .send({
+          displayName: "Nooby Noob",
+          email: "nooby@example.com",
+          phoneNumber: "+351234"
+        })
+        .set('Accept', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(500);
+      });
+
+      it('on empty value', async () => {
+
+        await supertest
+          .agent(app.getHttpServer())
+          .post('/users/register')
+          .send({
+            displayName: "Nooby Noob",
+            email: "nooby@example.com",
+            phoneNumber: ""
+          })
+          .set('Accept', 'application/json')
+          .expect('Content-Type', /json/)
+          .expect(500);
+
+      });    
+    });
 
   });
 });


### PR DESCRIPTION
This pull request add phone number field and some validation to check if this is valid.

New field on `post /user/register` `phoneNumber`, 

The phoneNumber is required field, It's required pass the `+` with rest of numbers. You can pass `spaces` and `hyphen` and `other characters`. The max length of plus and numbers needs to be `15`.

Example:
- `+1123456789` Valid
- `+55 (84) 98831-3333`, Valid. 
- `+55 84 98831 3333`, Valid. 
- `+999 84988313333`, Valid. 
- `1123456789` Invalid


It's need to run `npm run migration:run` after merge this. 

Note:

I opted to create a cleaning method to improve data capture, and decided to force the country code to better validate this in the future. I also increased the column size to try to meet all international types of numbers

